### PR TITLE
Support installing and uninstalling in a custom directory

### DIFF
--- a/src/bin/tvm-build.rs
+++ b/src/bin/tvm-build.rs
@@ -8,6 +8,9 @@ struct InstallCommand {
     revision: String,
     repository: Option<String>,
     #[structopt(short, long)]
+    /// The directory to build TVM in.
+    output_path: Option<String>,
+    #[structopt(short, long)]
     debug: bool,
     #[structopt(short, long)]
     clean: bool,
@@ -21,6 +24,9 @@ struct InstallCommand {
 #[structopt()]
 struct UninstallCommand {
     revision: String,
+    #[structopt(short, long)]
+    /// The directory that TVM was built in.
+    output_path: Option<String>
 }
 
 #[derive(StructOpt, Debug)]
@@ -51,12 +57,13 @@ fn main() -> anyhow::Result<()> {
             config.clean = install_cmd.clean;
             config.repository = install_cmd.repository;
             config.verbose = install_cmd.verbose;
+            config.output_path = install_cmd.output_path;
             config.settings = install_cmd.settings;
             build(config)?;
             Ok(())
         }
         TVMBuildArgs::Uninstall(uninstall_cmd) => {
-            tvm_build::uninstall(uninstall_cmd.revision)?;
+            tvm_build::uninstall(uninstall_cmd.revision, uninstall_cmd.output_path)?;
             Ok(())
         }
         TVMBuildArgs::VersionConfig(version_cmd) => {

--- a/src/core.rs
+++ b/src/core.rs
@@ -290,7 +290,7 @@ impl BuildConfig {
         let repository_url = self.repository.clone().unwrap_or(TVM_REPO.into());
 
         let branch = self.branch.clone().unwrap_or(DEFAULT_BRANCH.into());
-        let revision = Revision::new(branch);
+        let revision = Revision::new(branch, self.output_path.clone());
 
         let revision_path = match &self.repository_path {
             Some(path) => std::path::Path::new(&path).into(),
@@ -552,15 +552,22 @@ impl BuildConfig {
 
 pub struct Revision {
     revision: String,
+    output_path: Option<String>,
 }
 
 impl Revision {
-    pub fn new(revision: String) -> Revision {
-        Revision { revision }
+    pub fn new(revision: String, output_path: Option<String>) -> Revision {
+        Revision { revision, output_path }
     }
 
     pub fn path(&self) -> PathBuf {
-        tvm_build_directory().join(&self.revision)
+        let path =
+            if let Some(path) = self.output_path.as_ref() {
+                PathBuf::from(path)
+            } else {
+                tvm_build_directory()
+            };
+        path.join(&self.revision)
     }
 
     pub fn source_path(&self) -> PathBuf {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,13 +23,6 @@ pub fn build(build_config: core::BuildConfig) -> Result<core::BuildResult, core:
     let rev = build_config.get_revision()?;
     let target = local_target();
 
-    // TODO(@jroesch): map this to target triple based target directory
-    // should probably be target + host + profile.
-    match build_config.output_path {
-        None => (),
-        _ => panic!("this option is currently disabled"),
-    };
-
     rev.build_for(&build_config, target)?;
 
     // info!(target = target.target_str);
@@ -38,14 +31,15 @@ pub fn build(build_config: core::BuildConfig) -> Result<core::BuildResult, core:
     Ok(core::BuildResult { revision: rev })
 }
 
-pub fn uninstall(revision: String) -> Result<(), core::Error> {
-    let directory = core::tvm_build_directory().join(revision);
+pub fn uninstall(revision: String, output_path: Option<String>) -> Result<(), core::Error> {
+    let revision = Revision::new(revision, output_path);
+    let directory = revision.path();
     std::fs::remove_dir(directory)?;
     Ok(())
 }
 
 pub fn version_config(revision: String) -> Result<VersionConfig, core::Error> {
-    let rev = Revision::new(revision);
+    let rev = Revision::new(revision, None);
     let version = VersionConfig {
         tvm_python_path: rev.source_path().join("python").join("tvm"),
     };


### PR DESCRIPTION
Threads `output_path` around to install and uninstall to support building TVM in a custom location.