### PR TITLE
unifided mkldnn and dnnl_codegen to 'use_dnnl'

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -170,12 +170,9 @@ pub struct UserSettings {
     // tvm_option(USE_MKL "MKL root path when use MKL blas" OFF)
     #[structopt(long)]
     pub use_mkl: Option<CMakeSetting>,
-    /// "Build with MKLDNN"
+    /// Enable DNNL.
     #[structopt(long)]
-    pub use_mkldnn: Option<CMakeSetting>,
-    /// Enable MKLDNN (DNNL) codegen.
-    #[structopt(long)]
-    pub use_dnnl_codegen: Option<bool>,
+    pub use_dnnl: Option<bool>,
     // tvm_opt"Build with cuDNN" OFF)
     #[structopt(long)]
     pub use_cudnn: Option<bool>,
@@ -365,8 +362,7 @@ impl BuildConfig {
             use_byodt_posit,
             use_blas,
             use_mkl,
-            use_mkldnn,
-            use_dnnl_codegen,
+            use_dnnl,
             use_cudnn,
             use_cublas,
             use_thrust,
@@ -475,12 +471,9 @@ impl BuildConfig {
             use_mkl
                 .as_ref()
                 .map(|s| Self::setting_key_value("USE_MKL", s)),
-            use_mkldnn
+            use_dnnl
                 .as_ref()
-                .map(|s| Self::setting_key_value("USE_MKLDNN", s)),
-            use_dnnl_codegen
-                .as_ref()
-                .map(|s| Self::setting_key_value("USE_DNNL_CODEGEN", s)),
+                .map(|s| Self::setting_key_value("USE_DNNL", s)),
             use_cudnn
                 .as_ref()
                 .map(|s| Self::setting_key_value("USE_CUDNN", s)),


### PR DESCRIPTION
name "MKL-DNN" was discarded by Intel and updated as "DNNL" (aka Intel OneDNN),  as part of Intel OneAPI , 
so this PR mainly focus on deprecate MKL-DNN and use DNNL for the interface,

we are trying to unify the flag `use_mkl` and `use_dnnl_codegen` to `use_dnnl` [here in TVM](https://github.com/apache/tvm/pull/11638)

seems  tvm_build 0.2.4 should be updated before updating the rust file in TVM repo.
 
